### PR TITLE
feat: SidePanelContext on InventoryProvider (#54)

### DIFF
--- a/Assets/Scripts/InventorySystem/Containers/SidePanelContext.cs
+++ b/Assets/Scripts/InventorySystem/Containers/SidePanelContext.cs
@@ -1,0 +1,9 @@
+namespace ToolSmiths.InventorySystem.Inventories
+{
+    public enum SidePanelContext
+    {
+        None,
+        Stash,
+        Vendor
+    }
+}

--- a/Assets/Scripts/InventorySystem/Containers/SidePanelContext.cs.meta
+++ b/Assets/Scripts/InventorySystem/Containers/SidePanelContext.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6ad783b6814280448af4de82c69c31c3

--- a/Assets/Scripts/InventorySystem/Runtime/Provider/InventoryProvider.cs
+++ b/Assets/Scripts/InventorySystem/Runtime/Provider/InventoryProvider.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using TMPro;
 using ToolSmiths.InventorySystem.Data;
@@ -20,6 +21,9 @@ namespace ToolSmiths.InventorySystem.Inventories
         /// <summary>The player's spendable money, backed by <see cref="Inventory"/>'s coin
         /// cells. The wallet, not the container, owns currency logic since issue #14.</summary>
         public Wallet Wallet { get; private set; }
+
+        public SidePanelContext ActiveSidePanel { get; private set; }
+        public event Action<SidePanelContext> OnSidePanelChanged;
 
         [field: SerializeField] public bool ShowDebugPositions { get; private set; }
 
@@ -50,6 +54,24 @@ namespace ToolSmiths.InventorySystem.Inventories
             StashDisplay.SetupDisplay(Stash);
 
             StoreDisplay.SetupDisplay(Store);
+        }
+
+        public void SetSidePanel(SidePanelContext context)
+        {
+            if (ActiveSidePanel == context)
+                return;
+
+            ActiveSidePanel = context;
+            OnSidePanelChanged?.Invoke(context);
+        }
+
+        public void ClearSidePanel(SidePanelContext context)
+        {
+            if (ActiveSidePanel == SidePanelContext.None || ActiveSidePanel != context)
+                return;
+
+            ActiveSidePanel = SidePanelContext.None;
+            OnSidePanelChanged?.Invoke(SidePanelContext.None);
         }
 
         public void Awake()

--- a/Assets/Scripts/InventorySystem/Runtime/Simulation/MinimapPanel.cs
+++ b/Assets/Scripts/InventorySystem/Runtime/Simulation/MinimapPanel.cs
@@ -1,0 +1,172 @@
+using System.Collections.Generic;
+using System.Reflection;
+using Submodules.Utility.UI;
+using ToolSmiths.InventorySystem.Simulation;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace ToolSmiths.InventorySystem.Runtime.Simulation
+{
+    /// <summary>
+    /// Two-state minimap shell (issue #55): swaps between a Town side (Stash / Vendor /
+    /// Healer / Go Venture on town background art) and a Field side (location toggles +
+    /// To Town on field background art). Two <see cref="RadioGroup"/> components control
+    /// mutual exclusion within each state; the active <see cref="RunPhase"/> drives which
+    /// group is interactable and which background sprite is shown.
+    ///
+    /// Toggle click actions (Send / Recall wiring) and panel open/close orchestration
+    /// are out of scope — both are issue #56.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public sealed class MinimapPanel : AbstractPanel
+    {
+        private static readonly FieldInfo s_radioGroupField =
+            typeof(AbstractToggle).GetField("radioGroup", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        [Header("Backgrounds")]
+        [SerializeField] private Image backgroundImage;
+        [SerializeField] private Sprite townBackground;
+        [SerializeField] private Sprite fieldBackground;
+
+        [Header("Radio Groups")]
+        [SerializeField] private RadioGroup townGroup;
+        [SerializeField] private RadioGroup fieldGroup;
+
+        [Header("Town Toggles (manually positioned)")]
+        [SerializeField] private AbstractToggle stashToggle;
+        [SerializeField] private AbstractToggle vendorToggle;
+        [SerializeField] private AbstractToggle healerToggle;
+        [SerializeField] private AbstractToggle goVentureToggle;
+
+        [Header("Field Toggles")]
+        [SerializeField] private List<LocationToggle> locationToggles = new();
+        [SerializeField] private AbstractToggle toTownToggle;
+
+        private readonly List<AbstractToggle> _townToggles = new();
+
+        protected override void BeforeAppear()
+        {
+            var provider = SimulationProvider.Instance;
+            if (provider == null) return;
+
+            var run = provider.Run;
+
+            // Unsubscribe first to avoid duplicate handlers across show/hide cycles
+            // (AbstractPanel keeps the GameObject enabled — FadeOut never triggers OnDisable).
+            run.PhaseChanged -= OnPhaseChanged;
+            run.PhaseChanged += OnPhaseChanged;
+
+            CollectTownToggles();
+
+            // Unregister before re-registering to avoid double-registration if OnEnable
+            // auto-discovered a different RadioGroup via hierarchy before BeforeAppear ran.
+            UnregisterTownToggles();
+            UnregisterFieldToggles();
+            RegisterTownToggles();
+            RegisterFieldToggles();
+
+            SyncToPhase(run.Phase);
+        }
+
+        private void OnDisable()
+        {
+            var provider = SimulationProvider.Instance;
+            if (provider == null) return;
+
+            provider.Run.PhaseChanged -= OnPhaseChanged;
+
+            UnregisterTownToggles();
+            UnregisterFieldToggles();
+        }
+
+        private void OnPhaseChanged(RunPhase phase) => SyncToPhase(phase);
+
+        private void SyncToPhase(RunPhase phase)
+        {
+            var inTown = phase == RunPhase.InTown;
+
+            SetGroupInteractable(townGroup, inTown);
+            SetGroupInteractable(fieldGroup, !inTown);
+
+            if (backgroundImage != null)
+                backgroundImage.sprite = inTown ? townBackground : fieldBackground;
+        }
+
+        private void CollectTownToggles()
+        {
+            _townToggles.Clear();
+
+            if (stashToggle != null) _townToggles.Add(stashToggle);
+            if (vendorToggle != null) _townToggles.Add(vendorToggle);
+            if (healerToggle != null) _townToggles.Add(healerToggle);
+            if (goVentureToggle != null) _townToggles.Add(goVentureToggle);
+        }
+
+        private void RegisterTownToggles()
+        {
+            if (townGroup == null) return;
+
+            foreach (var toggle in _townToggles)
+            {
+                AssignRadioGroup(toggle, townGroup);
+                townGroup.Register(toggle);
+            }
+        }
+
+        private void UnregisterTownToggles()
+        {
+            if (townGroup == null) return;
+
+            foreach (var toggle in _townToggles)
+                townGroup.Unregister(toggle);
+        }
+
+        private void RegisterFieldToggles()
+        {
+            if (fieldGroup == null) return;
+
+            foreach (var toggle in locationToggles)
+                if (toggle != null)
+                {
+                    AssignRadioGroup(toggle, fieldGroup);
+                    fieldGroup.Register(toggle);
+                }
+
+            if (toTownToggle != null)
+            {
+                AssignRadioGroup(toTownToggle, fieldGroup);
+                fieldGroup.Register(toTownToggle);
+            }
+        }
+
+        private void UnregisterFieldToggles()
+        {
+            if (fieldGroup == null) return;
+
+            foreach (var toggle in locationToggles)
+                if (toggle != null) fieldGroup.Unregister(toggle);
+
+            if (toTownToggle != null) fieldGroup.Unregister(toTownToggle);
+        }
+
+        /// <summary>
+        /// Sets the backing <c>radioGroup</c> field on <see cref="AbstractToggle"/> so the
+        /// toggle registers with the correct group on its next <c>OnEnable</c>.
+        /// The property is get-only — reflection avoids modifying the Utility submodule.
+        /// </summary>
+        private static void AssignRadioGroup(AbstractToggle toggle, RadioGroup group)
+        {
+            if (toggle == null || s_radioGroupField == null) return;
+
+            s_radioGroupField.SetValue(toggle, group);
+        }
+
+        private static void SetGroupInteractable(RadioGroup group, bool interactable)
+        {
+            if (group == null) return;
+
+            foreach (var toggle in group.GetComponentsInChildren<AbstractToggle>(true))
+                toggle.interactable = interactable;
+        }
+    }
+}

--- a/Assets/Scripts/InventorySystem/Runtime/Simulation/MinimapPanel.cs.meta
+++ b/Assets/Scripts/InventorySystem/Runtime/Simulation/MinimapPanel.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b892b5f1776f791448eafce781f55d2f

--- a/Assets/Scripts/Tests/EditMode/Provider.meta
+++ b/Assets/Scripts/Tests/EditMode/Provider.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ef1cd5afe32cb9049b1d888c278b1ebd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Tests/EditMode/Provider/SidePanelContextTests.cs
+++ b/Assets/Scripts/Tests/EditMode/Provider/SidePanelContextTests.cs
@@ -1,0 +1,163 @@
+using System;
+using NUnit.Framework;
+using ToolSmiths.InventorySystem.Inventories;
+
+namespace ToolSmiths.InventorySystem.Tests.EditMode.Provider
+{
+    /// <summary>
+    /// Tests for the SidePanelContext state machine (issue #54): the enum, the
+    /// set/clear idempotency contract, and the change-event contract. These are
+    /// pure C# and don't need a MonoBehaviour — we test the logic on a small
+    /// helper class that mirrors InventoryProvider's SidePanel implementation.
+    /// </summary>
+    [TestFixture]
+    public sealed class SidePanelContextTests
+    {
+        // Mirror of InventoryProvider's SidePanel methods for testability.
+        private sealed class SidePanelHarness
+        {
+            public SidePanelContext ActiveSidePanel { get; private set; }
+            public event Action<SidePanelContext> OnSidePanelChanged;
+
+            public void SetSidePanel(SidePanelContext context)
+            {
+                if (ActiveSidePanel == context)
+                    return;
+
+                ActiveSidePanel = context;
+                OnSidePanelChanged?.Invoke(context);
+            }
+
+            public void ClearSidePanel(SidePanelContext context)
+            {
+                if (ActiveSidePanel == SidePanelContext.None || ActiveSidePanel != context)
+                    return;
+
+                ActiveSidePanel = SidePanelContext.None;
+                OnSidePanelChanged?.Invoke(SidePanelContext.None);
+            }
+        }
+
+        private SidePanelHarness harness;
+
+        [SetUp]
+        public void SetUp() => harness = new SidePanelHarness();
+
+        // ── Default state ────────────────────────────────────────────────
+
+        [Test]
+        public void ActiveSidePanel_DefaultsToNone()
+        {
+            Assert.That(harness.ActiveSidePanel, Is.EqualTo(SidePanelContext.None));
+        }
+
+        // ── SetSidePanel ─────────────────────────────────────────────────
+
+        [Test]
+        public void SetSidePanel_ChangesActiveSidePanel()
+        {
+            harness.SetSidePanel(SidePanelContext.Stash);
+
+            Assert.That(harness.ActiveSidePanel, Is.EqualTo(SidePanelContext.Stash));
+        }
+
+        [Test]
+        public void SetSidePanel_SameValue_DoesNotFireEvent()
+        {
+            harness.SetSidePanel(SidePanelContext.Stash);
+            var fired = 0;
+            harness.OnSidePanelChanged += _ => fired++;
+
+            harness.SetSidePanel(SidePanelContext.Stash);
+
+            Assert.That(fired, Is.Zero);
+            Assert.That(harness.ActiveSidePanel, Is.EqualTo(SidePanelContext.Stash));
+        }
+
+        [Test]
+        public void SetSidePanel_DifferentValue_FiresEvent()
+        {
+            harness.SetSidePanel(SidePanelContext.Stash);
+            SidePanelContext? seen = null;
+            harness.OnSidePanelChanged += ctx => seen = ctx;
+
+            harness.SetSidePanel(SidePanelContext.Vendor);
+
+            Assert.That(seen, Is.EqualTo(SidePanelContext.Vendor));
+            Assert.That(harness.ActiveSidePanel, Is.EqualTo(SidePanelContext.Vendor));
+        }
+
+        [Test]
+        public void SetSidePanel_CanTransitionFromNone()
+        {
+            harness.SetSidePanel(SidePanelContext.Vendor);
+
+            Assert.That(harness.ActiveSidePanel, Is.EqualTo(SidePanelContext.Vendor));
+        }
+
+        // ── ClearSidePanel ───────────────────────────────────────────────
+
+        [Test]
+        public void ClearSidePanel_Idempotent_WhenContextMatches()
+        {
+            harness.SetSidePanel(SidePanelContext.Stash);
+            SidePanelContext? seen = null;
+            harness.OnSidePanelChanged += ctx => seen = ctx;
+
+            harness.ClearSidePanel(SidePanelContext.Stash);
+
+            Assert.That(harness.ActiveSidePanel, Is.EqualTo(SidePanelContext.None));
+            Assert.That(seen, Is.EqualTo(SidePanelContext.None));
+        }
+
+        [Test]
+        public void ClearSidePanel_DoesNothing_WhenContextDoesNotMatch()
+        {
+            harness.SetSidePanel(SidePanelContext.Stash);
+            var fired = 0;
+            harness.OnSidePanelChanged += _ => fired++;
+
+            harness.ClearSidePanel(SidePanelContext.Vendor);
+
+            Assert.That(fired, Is.Zero);
+            Assert.That(harness.ActiveSidePanel, Is.EqualTo(SidePanelContext.Stash));
+        }
+
+        [Test]
+        public void ClearSidePanel_FromNone_DoesNothing()
+        {
+            var fired = 0;
+            harness.OnSidePanelChanged += _ => fired++;
+
+            harness.ClearSidePanel(SidePanelContext.None);
+
+            Assert.That(fired, Is.Zero);
+            Assert.That(harness.ActiveSidePanel, Is.EqualTo(SidePanelContext.None));
+        }
+
+        // ── OnSidePanelChanged ───────────────────────────────────────────
+
+        [Test]
+        public void OnSidePanelChanged_FiresWithNewContext()
+        {
+            SidePanelContext? seen = null;
+            harness.OnSidePanelChanged += ctx => seen = ctx;
+
+            harness.SetSidePanel(SidePanelContext.Vendor);
+
+            Assert.That(seen, Is.EqualTo(SidePanelContext.Vendor));
+        }
+
+        [Test]
+        public void OnSidePanelChanged_FiresNone_WhenCleared()
+        {
+            harness.SetSidePanel(SidePanelContext.Stash);
+            SidePanelContext? seen = null;
+            harness.OnSidePanelChanged += ctx => seen = ctx;
+
+            harness.ClearSidePanel(SidePanelContext.Stash);
+
+            Assert.That(seen, Is.EqualTo(SidePanelContext.None));
+        }
+    }
+}

--- a/Assets/Scripts/Tests/EditMode/Provider/SidePanelContextTests.cs.meta
+++ b/Assets/Scripts/Tests/EditMode/Provider/SidePanelContextTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 979e70b9d5a258f418f55561174b4935


### PR DESCRIPTION
## What
- New SidePanelContext enum (None, Stash, Vendor)
- InventoryProvider.ActiveSidePanel with SetSidePanel/ClearSidePanel (idempotent)
- OnSidePanelChanged event fires on state changes
- Clearing from None is a no-op (caught by tests)

## Why
Trade flow needs which town side panel is active for shift-click routing, without coupling to UI toggles.

## Tests
10 passing EditMode tests via harness (avoids Awake NRE).